### PR TITLE
Allow for setting the base working directory within ProcessInterface

### DIFF
--- a/source/ConsoleControlAPI/ProcessInterface.cs
+++ b/source/ConsoleControlAPI/ProcessInterface.cs
@@ -168,6 +168,62 @@ namespace ConsoleControlAPI
         }
 
         /// <summary>
+        /// Runs a process.
+        /// </summary>
+        /// <param name="fileName">Name of the file.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="workingDirectory">Starting folder.</param>
+        public void StartProcess(string fileName, string arguments, string workingDirectory)
+        {
+            //  Create the process start info.
+            var processStartInfo = new ProcessStartInfo(fileName, arguments);
+
+            //  Set the options.
+            processStartInfo.UseShellExecute = false;
+            processStartInfo.ErrorDialog = false;
+            processStartInfo.CreateNoWindow = true;
+            processStartInfo.WorkingDirectory = workingDirectory;
+
+            //  Specify redirection.
+            processStartInfo.RedirectStandardError = true;
+            processStartInfo.RedirectStandardInput = true;
+            processStartInfo.RedirectStandardOutput = true;
+
+            //  Create the process.
+            process = new Process();
+            process.EnableRaisingEvents = true;
+            process.StartInfo = processStartInfo;
+            process.Exited += currentProcess_Exited;
+
+            //  Start the process.
+            try
+            {
+                process.Start();
+            }
+            catch (Exception e)
+            {
+                //  Trace the exception.
+                Trace.WriteLine("Failed to start process " + fileName + " with arguments '" + arguments + "'");
+                Trace.WriteLine(e.ToString());
+                return;
+            }
+
+            //  Store name and arguments.
+            processFileName = fileName;
+            processArguments = arguments;
+
+            //  Create the readers and writers.
+            inputWriter = process.StandardInput;
+            outputReader = TextReader.Synchronized(process.StandardOutput);
+            errorReader = TextReader.Synchronized(process.StandardError);
+
+            //  Run the workers that read output and error.
+            outputWorker.RunWorkerAsync();
+            errorWorker.RunWorkerAsync();
+        }
+
+
+        /// <summary>
         /// Stops the process.
         /// </summary>
         public void StopProcess()


### PR DESCRIPTION
* Added an override too `StartProcess`, that allows for changing the base working directory within the `ProcessInterface` object.