### PR TITLE
Update to NET 6.0 & NET 7.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 
 build:

--- a/source/ConsoleControl.WPF/ConsoleControl.WPF.csproj
+++ b/source/ConsoleControl.WPF/ConsoleControl.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;net40</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net7.0-windows;net46</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>

--- a/source/ConsoleControl/ConsoleControl.csproj
+++ b/source/ConsoleControl/ConsoleControl.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;net40</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net7.0-windows;net46</TargetFrameworks>
     <OutputType>Library</OutputType>
     <PublishUrl>publish\</PublishUrl>
     <MapFileExtensions>true</MapFileExtensions>

--- a/source/ConsoleControlAPI/ConsoleControlAPI.csproj
+++ b/source/ConsoleControlAPI/ConsoleControlAPI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net46</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/source/ConsoleControlSample.WPF/ConsoleControlSample.WPF.csproj
+++ b/source/ConsoleControlSample.WPF/ConsoleControlSample.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/ConsoleControlSample/ConsoleControlSample.csproj
+++ b/source/ConsoleControlSample/ConsoleControlSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <ApplicationIcon>Console.ico</ApplicationIcon>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/source/SharedAssemblyInfo.cs
+++ b/source/SharedAssemblyInfo.cs
@@ -2,7 +2,7 @@
 
 [assembly: AssemblyCompany("Dave Kerr")]
 [assembly: AssemblyProduct("ConsoleControl")]
-[assembly: AssemblyCopyright("Copyright © Dave Kerr 2013-2020. https://www.dwmkerr.com")]
+[assembly: AssemblyCopyright("Copyright © Dave Kerr 2013-2023. https://www.dwmkerr.com")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -14,5 +14,5 @@
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/source/build.ps1
+++ b/source/build.ps1
@@ -1,5 +1,5 @@
 # Run msbuild on the solution, in release mode.
-$msbuild ="${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+$msbuild ="${env:ProgramFiles}\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
 $args = "ConsoleControl.sln /t:Rebuild /p:Configuration=Release"
 
 # Run the command.


### PR DESCRIPTION
Drops net 4.0 for net 4.6 as there are some issues in VS 2022 to build older .NET projects.

Also updates appveyor to use Visual Studio 2022

Fixes: https://github.com/dwmkerr/consolecontrol/issues/59